### PR TITLE
Add sync action so we can get roles from ext idp

### DIFF
--- a/src/SFA.DAS.ToolService.Web/Controllers/Admin/AdminRoleController.cs
+++ b/src/SFA.DAS.ToolService.Web/Controllers/Admin/AdminRoleController.cs
@@ -32,5 +32,11 @@ namespace SFA.DAS.ToolService.Web.Controllers.Admin
             return View(model);
         }
 
+        [HttpGet("sync", Name = AdminRoleRouteNames.SyncRoles)]
+        public async Task<IActionResult> SyncRolesFromExternalProvider()
+        {
+            await roleService.SyncIdentityProviderRoles();
+            return RedirectToAction(AdminRoleRouteNames.ManageRoles);
+        }
     }
 }


### PR DESCRIPTION
@nbowes24 Fixes a bug where we can no longer pull roles from Auth0. For now given the infrequent use, we just need to GET admin/manage-roles/sync to get the roles in to the DB.

