### PR TITLE
Removed DfE Signin bullet point.

### DIFF
--- a/src/SFA.DAS.ToolService.Web/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.ToolService.Web/Views/Home/Index.cshtml
@@ -14,11 +14,10 @@
 
         <h2 class="govuk-heading-m">Before you start</h2>
 
-        <p class="govuk-body">You will need one of the following:</p>
+        <p class="govuk-body">You will need the following:</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>a GitHub account that is member of the <a class="govuk-link" href="@Model.GitHubOrgAddress" target="_blank">SkillsFundingAgency</a> organisation.</li>
-            <li>a <a class="govuk-link" href="@Model.DfeSignInAddress" target="_blank">DfE Sign-In</a> account.</li>
         </ul>
         <a asp-action="@nameof(AccountController.Login)" asp-controller="@typeof(AccountController).GetControllerName()" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">
             Sign in


### PR DESCRIPTION
DfE Signin should not be used anywhere in the Apprenticeship Service. This PR removes a bullet point stating that you can use a DfE Sign email address to use the internal tooling service.