### PR TITLE
Upgrade to .NET 8 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 
 ENV PROJECT_PATH=SFA.DAS.ToolService.Web/SFA.DAS.ToolService.Web.csproj
 COPY ./src ./src
@@ -8,7 +8,7 @@ RUN dotnet restore $PROJECT_PATH
 RUN dotnet build $PROJECT_PATH -c release --no-restore
 RUN dotnet publish $PROJECT_PATH -c release --no-build -o /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 WORKDIR /app
 COPY --from=build /app .
 RUN apk add --no-cache icu-libs

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -9,9 +9,9 @@ metadata:
   namespace: {{KubernetesNamespace}}
 spec:
   ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 80
+    - port: 80
+      protocol: TCP
+      targetPort: 80
   selector:
     app: das-tool-service-web
   type: ClusterIP
@@ -42,30 +42,45 @@ spec:
         app: das-tool-service-web
         service: das-tool-service
     spec:
+      terminationGracePeriodSeconds: 30
       nodeSelector:
         agentpool: {{toolsAgentName}}
       containers:
-      - env:
-        - name: AzureAdConfiguration__Authority
-          value: https://login.microsoftonline.com/{{Tenant}}
-        - name: AzureAdConfiguration__ClientId
-          value: {{ToolsServiceAadOidcClientId}}
-        - name: AzureAdConfiguration__ClientSecret
-          value: {{ToolsServiceAadOidcClientSecret}}
-        - name: DatabaseConnectionString
-          value: {{DatabaseConnectionString}}
-        - name: DfESigninAddress
-          value: {{DfeSignInAddress}}
-        image: {{PublicAcrName}}.azurecr.io/das-tools-service:{{buildNumber}}
-        imagePullPolicy: IfNotPresent
-        name: das-tool-service
-        envFrom:
-          - configMapRef:
-              name: das-tool-service-shared-config
-        ports:
-        - containerPort: 80
-          protocol: TCP
-        resources:
+        - name: das-tool-service
+          image: {{PublicAcrName}}.azurecr.io/das-tools-service:{{buildNumber}}
+          imagePullPolicy: Always
+          env:
+            - name: AzureAdConfiguration__Authority
+              value: https://login.microsoftonline.com/{{Tenant}}
+            - name: AzureAdConfiguration__ClientId
+              value: {{ToolsServiceAadOidcClientId}}
+            - name: AzureAdConfiguration__ClientSecret
+              value: {{ToolsServiceAadOidcClientSecret}}
+            - name: DatabaseConnectionString
+              value: {{DatabaseConnectionString}}
+            - name: DfESigninAddress
+              value: {{DfeSignInAddress}}
+            - name: ASPNETCORE_URLS
+              value: "http://+:80;https://+:443"
+          envFrom:
+            - configMapRef:
+                name: das-tool-service-shared-config
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
             requests:
               cpu: 25m
               memory: 512Mi

--- a/manifests/ingress.yml
+++ b/manifests/ingress.yml
@@ -8,15 +8,17 @@ metadata:
     appgw.ingress.kubernetes.io/appgw-ssl-certificate: {{TlsSecretName}}
     appgw.ingress.kubernetes.io/ssl-redirect: "true"
     appgw.ingress.kubernetes.io/health-probe-path: "/health"
+    appgw.ingress.kubernetes.io/health-probe-status-codes: "200"
+    appgw.ingress.kubernetes.io/backend-protocol: "HTTP"
 spec:
   rules:
-  - host: {{IngressHost}}
-    http:
-      paths:
-      - path: /
-        pathType: Exact
-        backend:
-          service:
-            name: das-tool-service-web
-            port:
-              number: 80
+    - host: {{IngressHost}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: das-tool-service-web
+                port:
+                  number: 80

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -1,4 +1,4 @@
-﻿parameters:
+parameters:
   AksResourceGroup:
   AppGatewayName:
   AppGatewayResourceGroup:
@@ -55,7 +55,7 @@ jobs:
             DatabaseName: '$(DatabaseName)'
             SqlUsername: '${{ parameters.SharedSQLServerUsername }}'
             SqlPassword: '${{ parameters.SharedSQLServerPassword }}'
-            DacpacFile: '$(Pipeline.Workspace)/database/SFA.DAS.ToolService.Database.dacpac'
+            DacpacFile: '$(Pipeline.Workspace)/database/src/SFA.DAS.ToolService.Database/bin/Output/SFA.DAS.ToolService.Database.dacpac'
         - task: KubectlInstaller@0
           displayName: 'Install Kubectl ${{ parameters.KubectlVersion }}'
           inputs:

--- a/pipeline-templates/stage/build.yml
+++ b/pipeline-templates/stage/build.yml
@@ -1,4 +1,4 @@
-﻿parameters:
+parameters:
   ServiceConnection:
 
 stages:
@@ -32,20 +32,32 @@ stages:
             manifests/**
           targetFolder: '$(build.artifactstagingdirectory)/publish'
 
-  - job: 'build_dacpac'
+  - job: build_dacpac
+    displayName: Build DACPAC
     pool:
-      name: 'DAS - Continuous Integration Agents'
+      name: 'DAS - Continuous Integration'
+      demands: Agent.OS -equals Windows_NT
     workspace:
       clean: all
     steps:
-    - task: DotNetCoreCLI@2
-      displayName: Build DACPAC
-      inputs:
-        projects: 'src/SFA.DAS.ToolService.Database/SFA.DAS.ToolService.Database.sqlproj'
-        arguments: '/p:NetCoreBuild=true --configuration $(buildConfiguration) -o $(build.artifactstagingdirectory)/publish'
+      - task: VSBuild@1
+        displayName: 'Build DACPAC'
+        inputs:
+          solution: 'src\**\*.sqlproj'
+          platform: '$(buildPlatform)'
+          configuration: '$(buildConfiguration)'
+          msbuildArgs: '/p:PackageLocation="$(build.artifactstagingdirectory)/publish"'
 
-    - task: PublishPipelineArtifact@0
-      displayName: 'Publish Artifact: database'
-      inputs:
-        targetPath: '$(build.artifactstagingdirectory)/publish'
-        artifactName: database
+      - task: CopyFiles@2
+        displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+        inputs:
+          Contents: |
+            src\**\*.dacpac
+          TargetFolder: '$(build.artifactstagingdirectory)/publish'
+          OverWrite: true
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact'
+        inputs:
+          PathtoPublish: '$(build.artifactstagingdirectory)/publish'
+          artifactName: database

--- a/src/SFA.DAS.ToolService.Core.UnitTests/SFA.DAS.ToolService.Core.UnitTests.csproj
+++ b/src/SFA.DAS.ToolService.Core.UnitTests/SFA.DAS.ToolService.Core.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>B2B3FDFA-F3B0-4220-B7FF-1D2CC7281AC0</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.ToolService.Core/SFA.DAS.ToolService.Core.csproj
+++ b/src/SFA.DAS.ToolService.Core/SFA.DAS.ToolService.Core.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <ProjectGuid>35501A08-31EB-49AD-8586-7B204C745BFF</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
     <PackageReference Include="SFA.DAS.ToolsNotifications.Types" Version="0.2.15" />
 
     <!-- Transitive Updates -->

--- a/src/SFA.DAS.ToolService.Database/SFA.DAS.ToolService.Database.sqlproj
+++ b/src/SFA.DAS.ToolService.Database/SFA.DAS.ToolService.Database.sqlproj
@@ -1,55 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0">
-  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <Name>SFA.DAS.ToolService.Database</Name>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectVersion>4.1</ProjectVersion>
-    <ProjectGuid>{fe9f219a-296e-4c88-9eda-18c7ed6579cf}</ProjectGuid>
-    <DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
-    <OutputType>Database</OutputType>
-    <RootPath>
-    </RootPath>
-    <RootNamespace>SFA.DAS.ToolService.Database</RootNamespace>
-    <AssemblyName>SFA.DAS.ToolService.Database</AssemblyName>
-    <ModelCollation>1033, CI</ModelCollation>
-    <DefaultFileStructure>BySchemaAndSchemaType</DefaultFileStructure>
-    <DeployToDatabase>True</DeployToDatabase>
-    <TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
-    <TargetLanguage>CS</TargetLanguage>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <SqlServerVerification>False</SqlServerVerification>
-    <IncludeCompositeObjects>True</IncludeCompositeObjects>
-    <TargetDatabaseSet>True</TargetDatabaseSet>
-    <Recovery>SIMPLE</Recovery>
-    <IsEncryptionOn>True</IsEncryptionOn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release\</OutputPath>
-    <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug\</OutputPath>
-    <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <PostDeploy Include="Scripts\PostDeployment\SeedDatabase.sql" />
-  </ItemGroup>
+    <Sdk Name="Microsoft.Build.Sql" Version="1.0.0-rc1" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <Name>SFA.DAS.ToolService.Database</Name>
+        <SchemaVersion>2.0</SchemaVersion>
+        <ProjectVersion>4.1</ProjectVersion>
+        <ProjectGuid>{fe9f219a-296e-4c88-9eda-18c7ed6579cf}</ProjectGuid>
+        <DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
+        <OutputType>Database</OutputType>
+        <RootPath></RootPath>
+        <RootNamespace>SFA.DAS.ToolService.Database</RootNamespace>
+        <AssemblyName>SFA.DAS.ToolService.Database</AssemblyName>
+        <ModelCollation>1033, CI</ModelCollation>
+        <DefaultFileStructure>BySchemaAndSchemaType</DefaultFileStructure>
+        <DeployToDatabase>True</DeployToDatabase>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <TargetLanguage>CS</TargetLanguage>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <SqlServerVerification>False</SqlServerVerification>
+        <IncludeCompositeObjects>True</IncludeCompositeObjects>
+        <TargetDatabaseSet>True</TargetDatabaseSet>
+        <Recovery>SIMPLE</Recovery>
+        <IsEncryptionOn>True</IsEncryptionOn>
+        <TargetFrameworkProfile />
+        <RuntimeIdentifiers>win;win-x64;linux-x64</RuntimeIdentifiers>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <OutputPath>bin\Release\</OutputPath>
+        <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>
+        <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+        <DebugType>none</DebugType>
+        <Optimize>true</Optimize>
+        <DefineDebug>false</DefineDebug>
+        <DefineTrace>true</DefineTrace>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <OutputPath>bin\Debug\</OutputPath>
+        <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <DebugSymbols>false</DebugSymbols>
+        <DebugType>none</DebugType>
+        <Optimize>false</Optimize>
+        <DefineDebug>true</DefineDebug>
+        <DefineTrace>true</DefineTrace>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <PostDeploy Include="Scripts\PostDeployment\SeedDatabase.sql" />
+    </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Scripts\" />
+        <Folder Include="Scripts\PostDeployment\" />
+    </ItemGroup>
 </Project>

--- a/src/SFA.DAS.ToolService.Infrastructure.UnitTests/SFA.DAS.ToolService.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.ToolService.Infrastructure.UnitTests/SFA.DAS.ToolService.Infrastructure.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>AD0657F2-0BEB-4FDD-8E78-7A8E4DFCC177</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.ToolService.Infrastructure/SFA.DAS.ToolService.Infrastructure.csproj
+++ b/src/SFA.DAS.ToolService.Infrastructure/SFA.DAS.ToolService.Infrastructure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>8F20F8C8-B733-484F-8211-06A0B7E7697E</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/SFA.DAS.ToolService.Web.UnitTests/SFA.DAS.ToolService.Web.UnitTests.csproj
+++ b/src/SFA.DAS.ToolService.Web.UnitTests/SFA.DAS.ToolService.Web.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>9031B37D-0251-4177-BDA6-294ECFE2D9F8</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.ToolService.Web/SFA.DAS.ToolService.Web.csproj
+++ b/src/SFA.DAS.ToolService.Web/SFA.DAS.ToolService.Web.csproj
@@ -1,30 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <ProjectGuid>8F5F5D09-6BE2-4573-8D90-E1D43CE657AB</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+    <PropertyGroup>
+        <ProjectGuid>8F5F5D09-6BE2-4573-8D90-E1D43CE657AB</ProjectGuid>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.8" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.22.0" />
-    <PackageReference Include="SFA.DAS.ToolsNotifications.Types" Version="0.2.15" />
-    <PackageReference Include="SFA.DAS.ToolsNotifications.Client" Version="0.2.15" />
-    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
+    <ItemGroup>
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="9.0.1" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.35.0" />
+        <PackageReference Include="SFA.DAS.ToolsNotifications.Types" Version="0.2.15" />
+        <PackageReference Include="SFA.DAS.ToolsNotifications.Client" Version="0.2.15" />
+        <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
+    </ItemGroup>
 
-    <!-- Transitive Updates -->
-    <!-- WebEssentials.AspNetCore.CdnTagHelpers -->
-    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\SFA.DAS.ToolService.Core\SFA.DAS.ToolService.Core.csproj" />
-    <ProjectReference Include="..\SFA.DAS.ToolService.Infrastructure\SFA.DAS.ToolService.Infrastructure.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\SFA.DAS.ToolService.Core\SFA.DAS.ToolService.Core.csproj" />
+        <ProjectReference Include="..\SFA.DAS.ToolService.Infrastructure\SFA.DAS.ToolService.Infrastructure.csproj" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
 Updated Target Framework and package references to upgrade solution to .NET 8
  Updated build and deploy to use windows to build the dacpac in order to use VSBuild task
  Updated Dockerfile to change base image to use mcr.microsoft.com/dotnet/sdk:8.0
 Overwrote .net8 listening ports from default to 80,443 and added readiness and liveness probes