### PR TITLE
Fix for HTTPS redirect handling behind app gateway

### DIFF
--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -56,6 +56,8 @@ spec:
               value: {{ToolsServiceAadOidcClientId}}
             - name: AzureAdConfiguration__ClientSecret
               value: {{ToolsServiceAadOidcClientSecret}}
+            - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+              value: "true"
             - name: DatabaseConnectionString
               value: {{DatabaseConnectionString}}
             - name: DfESigninAddress


### PR DESCRIPTION
Enable ASPNETCORE_FORWARDEDHEADERS_ENABLED to ensure ASP.NET respects X-Forwarded-Proto from application gateway - fixing AAD redirect URI mismatch